### PR TITLE
Fixed SingleObj environment

### DIFF
--- a/real_robots/envs/env.py
+++ b/real_robots/envs/env.py
@@ -242,12 +242,10 @@ class REALRobotEnv(MJCFBaseBulletEnv):
 
         return observation, reward, done, info
 
-
-class REALRobotEnvSingleObj(MJCFBaseBulletEnv):
+class REALRobotEnvSingleObj(REALRobotEnv):
     def __init__(self, render=False):
         super(REALRobotEnvSingleObj, self).__init__(render)
-        self.robot.used_objects = ["table", "orange"]
-
+        self.robot.used_objects = ["table", "cube"]
 
 class EnvCamera:
 


### PR DESCRIPTION
I fixed a bug which prevented loading the REALRobotSingleObj-v0 environment.
While it is not the environment which will be used for the evaluation, it can be useful for participants to test some approaches, so I took this occasion to fix it.