### PR TITLE
Fix goal miss match right after env reset - #23

### DIFF
--- a/real_robots/evaluate.py
+++ b/real_robots/evaluate.py
@@ -243,6 +243,9 @@ class EvaluationService:
         done = False
         self.env.set_goal()
 
+        observation['goal'] = self.env.goal.retina
+        assert (observation['goal'] == self.env.goal.retina).all(), "obs['goal'] is incorrect right after env reset"
+
         # Notify the controller that an extrinsic trial started
         self.controller.start_extrinsic_trial()
 


### PR DESCRIPTION
I fixed the problem described in #23.
I'm not sure what is the best way to write test code for this. Everything is encapsulated in evaluate() and it's very hard to write a test to check if obs['goal'] contains proper goal.
I simply added an assert statement in evaluate.py, but I would love to improve my code if you have a better idea.